### PR TITLE
Removed GitHub reference on main blog page

### DIFF
--- a/src/pages/treetest/index.md
+++ b/src/pages/treetest/index.md
@@ -3,7 +3,7 @@ title: "Tree testing using a clickable prototype"
 authors:
 - Lindsay Goldstein
 - Shannon McHarg
-excerpt: "We used GitHub a clickable prototype to conduct tree testing and thought we should share what we learned."
+excerpt: "We used a clickable prototype to conduct tree testing and thought we should share what we learned."
 tags:
 - user experience
 - onrr.gov


### PR DESCRIPTION
I noticed the summary on the main blog page still had the reference to GitHub, so I removed it.
![image](https://user-images.githubusercontent.com/38465926/102523390-7b556280-4065-11eb-8d35-b9f1a93c59da.png)
