### PR TITLE
Fixes title case

### DIFF
--- a/src/pages/Intern-Onboarding/index.md
+++ b/src/pages/Intern-Onboarding/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Joining the Team: My Onboarding Experience at the Office of Natural Resources Revenue"
+title: "Joining the team: my onboarding experience at the Office of Natural Resources Revenue"
 authors:
 - Sarah Aranda
 excerpt: "In this post, our intern discusses her experience with our team's onboarding process and takeaways from her experience."

--- a/src/pages/implementing-mdx/index.md
+++ b/src/pages/implementing-mdx/index.md
@@ -1,5 +1,5 @@
 ---
-title: "MDX, not your Parents' markdown"
+title: "MDX, not your parents' markdown"
 authors:
 - Jeff Keene
 excerpt: "We have decided to implement React components in our Markdown by using the new MDX format (Markdown for the component era). "

--- a/src/pages/implementing-mdx/index.md
+++ b/src/pages/implementing-mdx/index.md
@@ -1,5 +1,5 @@
 ---
-title: "MDX, Not Your Parent's Markdown"
+title: "MDX, not your Parents' markdown"
 authors:
 - Jeff Keene
 excerpt: "We have decided to implement React components in our Markdown by using the new MDX format (Markdown for the component era). "


### PR DESCRIPTION
Ryan noticed a couple of the blog post titles weren't in sentence case and we had the apostrophe in the wrong place on "parents'".

https://dev-blog-nrrd.app.cloud.gov/

![image](https://user-images.githubusercontent.com/38465926/102622456-0b031b80-410f-11eb-91ca-13fbd021fa26.png)
